### PR TITLE
Add SECURE_VAULT: zero-knowledge secret/.env sharing tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,8 @@ VITE_FIREBASE_STORAGE_BUCKET=
 VITE_FIREBASE_MESSAGING_SENDER_ID=
 VITE_FIREBASE_APP_ID=
 VITE_FIREBASE_MEASUREMENT_ID=
+
+# SECURE_VAULT backend — the deployed Cloudflare Worker URL. Optional: a public
+# default is baked into lib/vault-api.ts, so set this only to override (e.g. a
+# staging worker or a custom api.* route).
+VITE_VAULT_API_URL=

--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,5 @@
 {
   "projects": {
-    "default": "REPLACE_WITH_YOUR_FIREBASE_PROJECT_ID"
+    "default": "mehdi-00"
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ firebase-debug.log
 *.njsproj
 *.sln
 *.sw?
+
+# Cloudflare Wrangler local state
+.wrangler

--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { Github, Linkedin, Mail, MapPin } from 'lucide-react';
+import React, { useEffect, useState } from 'react';
+import { Github, Linkedin, Mail, Lock } from 'lucide-react';
 import { motion } from 'framer-motion';
 
 import SystemStatus from './components/SystemStatus';
@@ -8,6 +8,8 @@ import Projects from './components/Projects';
 import Terminal from './components/Terminal';
 import Skills from './components/Skills';
 import BootSequence from './components/BootSequence';
+import Vault from './components/Vault';
+import { normalizeCode } from './lib/vault-crypto';
 import { PROFILE } from './constants';
 
 const App: React.FC = () => {
@@ -15,6 +17,34 @@ const App: React.FC = () => {
   const [booting, setBooting] = useState<boolean>(() => {
     try { return localStorage.getItem('tu_boot_dismissed') !== '1'; } catch { return true; }
   });
+
+  // SECURE_VAULT modal. Opens via the hero button, the `vault` terminal command,
+  // the project card, or automatically when arriving on a #vault=<token> link.
+  const [vaultOpen, setVaultOpen] = useState(false);
+  const [vaultTab, setVaultTab] = useState<'send' | 'receive'>('send');
+  const [vaultToken, setVaultToken] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    // Deep link: someone opened a share link — jump straight into RECEIVE.
+    const hash = window.location.hash;
+    if (hash.startsWith('#vault=')) {
+      setVaultToken(normalizeCode(hash));
+      setVaultTab('receive');
+      setVaultOpen(true);
+      // Strip the secret from the URL so it isn't left lying in the address bar.
+      history.replaceState(null, '', window.location.pathname + window.location.search);
+    }
+
+    // Any component can request the vault via a window event (no prop drilling).
+    const onOpen = (e: Event) => {
+      const detail = (e as CustomEvent<{ tab?: 'send' | 'receive' }>).detail;
+      setVaultToken(undefined);
+      setVaultTab(detail?.tab ?? 'send');
+      setVaultOpen(true);
+    };
+    window.addEventListener('vault:open', onOpen as EventListener);
+    return () => window.removeEventListener('vault:open', onOpen as EventListener);
+  }, []);
 
   return (
     <div className="min-h-screen bg-zinc-950 text-zinc-200 font-sans selection:bg-cyan-900 selection:text-white pb-40">
@@ -60,6 +90,13 @@ const App: React.FC = () => {
 
             {/* Social Actions */}
             <div className="flex flex-col gap-3">
+              <button
+                onClick={() => window.dispatchEvent(new CustomEvent('vault:open', { detail: { tab: 'send' } }))}
+                className="flex items-center justify-between px-4 py-3 bg-cyan-950/30 border border-cyan-800/60 text-cyan-300 hover:border-cyan-500 hover:bg-cyan-900/30 transition-all group"
+              >
+                <span className="font-mono text-xs uppercase tracking-wider">Secure_Vault // Pass_Secrets</span>
+                <Lock size={16} className="text-cyan-600 group-hover:text-cyan-400" />
+              </button>
               <a href={`mailto:${PROFILE.email}`} className="flex items-center justify-between px-4 py-3 bg-zinc-950 border border-zinc-800 hover:border-cyan-500/50 hover:text-cyan-400 transition-all group">
                 <span className="font-mono text-xs uppercase">Init_Contact</span>
                 <Mail size={16} className="text-zinc-600 group-hover:text-cyan-500" />
@@ -98,6 +135,14 @@ const App: React.FC = () => {
 
       {/* Floating CLI Terminal */}
       <Terminal />
+
+      {/* SECURE_VAULT — zero-knowledge secret sharing */}
+      <Vault
+        open={vaultOpen}
+        initialTab={vaultTab}
+        initialToken={vaultToken}
+        onClose={() => setVaultOpen(false)}
+      />
     </div>
   );
 };

--- a/components/Projects.tsx
+++ b/components/Projects.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { motion } from 'framer-motion';
-import { Github, ExternalLink, Cpu } from 'lucide-react';
+import { Github, ExternalLink, Cpu, Lock } from 'lucide-react';
 import { PROJECTS } from '../constants';
 import { ProjectStatus } from '../types';
 
@@ -71,6 +71,15 @@ const Projects: React.FC = () => {
                 </p>
 
                 <div className="flex gap-4 mt-auto">
+                    {project.action === 'vault' && (
+                        <button
+                            onClick={() => window.dispatchEvent(new CustomEvent('vault:open', { detail: { tab: 'send' } }))}
+                            className="flex items-center gap-2 text-xs font-mono text-cyan-400 hover:text-cyan-300 transition-colors"
+                        >
+                            <Lock size={14} />
+                            <span>LAUNCH</span>
+                        </button>
+                    )}
                     {project.github && (
                         <a href={project.github} className="flex items-center gap-2 text-xs font-mono text-zinc-500 hover:text-zinc-200 transition-colors">
                             <Github size={14} />
@@ -83,7 +92,7 @@ const Projects: React.FC = () => {
                             <span>DEPLOY</span>
                         </a>
                     )}
-                    {!project.github && !project.link && (
+                    {!project.github && !project.link && !project.action && (
                         <span className="flex items-center gap-2 text-xs font-mono text-zinc-600 italic">
                             <span className="w-2 h-2 border border-zinc-700"></span>
                             QUEUED // SEE_BACKLOG

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -10,7 +10,7 @@ type TerminalState = 'CLOSED' | 'PEEK' | 'OPEN';
 const COMMANDS = [
   'help', 'status', 'projects', 'skills', 'timeline', 'whoami', 'contact',
   'neofetch', 'trace', 'whois', 'ls', 'cat', 'date', 'echo', 'clear',
-  'sudo dream', 'manhuascan',
+  'vault', 'sudo dream', 'manhuascan',
 ] as const;
 
 const ageYears = (): number =>
@@ -118,6 +118,12 @@ const Terminal: React.FC = () => {
 
     // Special handlers (async / stateful).
     if (cmd === 'clear') { setTimeout(() => setLines([]), 50); return; }
+    if (cmd === 'vault') {
+      const tab = arg === 'receive' || arg === 'open' || arg === 'get' ? 'receive' : 'send';
+      window.dispatchEvent(new CustomEvent('vault:open', { detail: { tab } }));
+      print({ type: 'system', content: `SECURE_VAULT // opening encrypted channel [${tab.toUpperCase()}] ...` });
+      return;
+    }
     if (lower === 'sudo dream' || cmd === 'manhuascan') { await typeWriterEffect(DREAM_LOG); return; }
     if (cmd === 'trace' || cmd === 'whois') { await runTrace(); return; }
 
@@ -137,6 +143,7 @@ const Terminal: React.FC = () => {
   ls          - List sections
   cat <name>  - Read a section (e.g. cat about, cat P1)
   neofetch    - System summary
+  vault       - Open SECURE_VAULT (share/receive encrypted secrets)
   trace       - Recon the current visitor (you)
   date        - Current system time
   echo <txt>  - Repeat input

--- a/components/Vault.tsx
+++ b/components/Vault.tsx
@@ -1,0 +1,564 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import {
+  Lock, Upload, Download, Copy, Check, KeyRound, ShieldCheck, Clock, Eye,
+  X, FileText, Trash2, Send, Inbox, Link2, AlertTriangle, Loader2, Plus,
+} from 'lucide-react';
+import {
+  generateToken, formatCode, normalizeCode, buildShareLink, deriveId,
+  encryptManifest, decryptManifest, fileToBase64, base64ToBlob, base64ToText,
+  VaultFile, VaultManifest,
+} from '../lib/vault-crypto';
+import { createSecret, openSecret } from '../lib/vault-api';
+import { track } from '../lib/firebase';
+
+type Tab = 'send' | 'receive';
+
+interface VaultProps {
+  open: boolean;
+  initialTab?: Tab;
+  initialToken?: string;
+  onClose: () => void;
+}
+
+const TTL_OPTIONS = [
+  { label: '1 hour', hours: 1 },
+  { label: '6 hours', hours: 6 },
+  { label: '24 hours', hours: 24 },
+  { label: '3 days', hours: 72 },
+  { label: '7 days', hours: 168 },
+];
+
+// Client-side soft cap on raw payload; the Worker enforces the real limit.
+const MAX_RAW_BYTES = 200_000;
+
+const ERRORS: Record<string, string> = {
+  not_found_or_expired: 'This key is invalid, already used up, or has expired.',
+  exhausted: 'This secret hit its access limit and has been destroyed.',
+  too_large: 'That payload is too large (keep it under ~200 KB).',
+  network_error: 'Could not reach the vault server. Check your connection and try again.',
+  id_exists: 'Key collision — please generate again.',
+  decrypt: 'Wrong key, or the data is corrupted.',
+};
+const friendly = (code: string) => ERRORS[code] ?? 'Something went wrong. Please try again.';
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / 1024 / 1024).toFixed(1)} MB`;
+}
+
+// Heuristic: does this base64 payload decode to mostly-printable text?
+function isProbablyText(b64: string): boolean {
+  try {
+    const bin = atob(b64.slice(0, 4096));
+    let control = 0;
+    for (let i = 0; i < bin.length; i++) {
+      const c = bin.charCodeAt(i);
+      if (c === 9 || c === 10 || c === 13) continue;
+      if (c < 32 || c === 127) control++;
+    }
+    return bin.length === 0 || control / bin.length < 0.1;
+  } catch {
+    return false;
+  }
+}
+
+// ---- small UI atoms --------------------------------------------------------
+
+const CopyButton: React.FC<{ value: string; label?: string; className?: string }> = ({ value, label = 'COPY', className = '' }) => {
+  const [done, setDone] = useState(false);
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setDone(true);
+      setTimeout(() => setDone(false), 1500);
+    } catch {
+      /* clipboard blocked */
+    }
+  };
+  return (
+    <button
+      onClick={copy}
+      className={`flex items-center gap-1.5 px-2.5 py-1.5 font-mono text-[11px] uppercase border transition-colors ${
+        done ? 'border-green-700 text-green-400' : 'border-zinc-700 text-zinc-400 hover:border-cyan-500/60 hover:text-cyan-400'
+      } ${className}`}
+    >
+      {done ? <Check size={13} /> : <Copy size={13} />}
+      {done ? 'COPIED' : label}
+    </button>
+  );
+};
+
+function downloadBlob(name: string, blob: Blob) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = name;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+// ===========================================================================
+
+const Vault: React.FC<VaultProps> = ({ open, initialTab = 'send', initialToken, onClose }) => {
+  const [tab, setTab] = useState<Tab>(initialTab);
+
+  // ---- SEND state ----
+  const [files, setFiles] = useState<VaultFile[]>([]);
+  const [text, setText] = useState('');
+  const [maxViews, setMaxViews] = useState(1);
+  const [ttlHours, setTtlHours] = useState(24);
+  const [creating, setCreating] = useState(false);
+  const [sendError, setSendError] = useState('');
+  const [result, setResult] = useState<{ code: string; link: string } | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [dragging, setDragging] = useState(false);
+
+  // ---- RECEIVE state ----
+  const [codeInput, setCodeInput] = useState('');
+  const [opening, setOpening] = useState(false);
+  const [recvError, setRecvError] = useState('');
+  const [manifest, setManifest] = useState<VaultManifest | null>(null);
+  const [remaining, setRemaining] = useState<number | null>(null);
+
+  // When opened via a share link, jump straight to RECEIVE and prefill the code.
+  useEffect(() => {
+    if (!open) return;
+    setTab(initialTab);
+    if (initialToken) {
+      setTab('receive');
+      setCodeInput(formatCode(normalizeCode(initialToken)));
+    }
+  }, [open, initialTab, initialToken]);
+
+  // Lock body scroll while the modal is open.
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  // Esc to close.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  const totalRaw = useMemo(
+    () => files.reduce((s, f) => s + f.size, 0) + new Blob([text]).size,
+    [files, text],
+  );
+
+  const addFiles = async (list: FileList | File[]) => {
+    setSendError('');
+    const incoming = Array.from(list);
+    const read: VaultFile[] = [];
+    for (const file of incoming) {
+      const b64 = await fileToBase64(file);
+      read.push({ name: file.name, b64, size: file.size });
+    }
+    setFiles((prev) => [...prev, ...read]);
+  };
+
+  const onDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setDragging(false);
+    if (e.dataTransfer.files?.length) addFiles(e.dataTransfer.files);
+  };
+
+  const removeFile = (idx: number) => setFiles((prev) => prev.filter((_, i) => i !== idx));
+
+  const resetSend = () => {
+    setFiles([]);
+    setText('');
+    setMaxViews(1);
+    setTtlHours(24);
+    setResult(null);
+    setSendError('');
+  };
+
+  const handleGenerate = async () => {
+    setSendError('');
+    if (files.length === 0 && text.trim() === '') {
+      setSendError('Add at least one file or some text to share.');
+      return;
+    }
+    if (totalRaw > MAX_RAW_BYTES) {
+      setSendError(`Payload is ${formatBytes(totalRaw)} — keep it under ${formatBytes(MAX_RAW_BYTES)}.`);
+      return;
+    }
+    setCreating(true);
+    try {
+      const manifestToSend: VaultManifest = {
+        files,
+        text: text.trim() ? text : undefined,
+      };
+      const token = generateToken();
+      const id = await deriveId(token);
+      const { ct, iv } = await encryptManifest(token, manifestToSend);
+      const contentType: 'files' | 'text' | 'mixed' =
+        files.length && manifestToSend.text ? 'mixed' : files.length ? 'files' : 'text';
+      await createSecret({ id, ct, iv, maxViews, ttlHours, contentType, size: totalRaw });
+      setResult({ code: formatCode(token), link: buildShareLink(token) });
+      track('vault_create', { contentType, maxViews, ttlHours });
+    } catch (e) {
+      setSendError(friendly(e instanceof Error ? e.message : ''));
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleUnlock = async () => {
+    setRecvError('');
+    setManifest(null);
+    setRemaining(null);
+    const token = normalizeCode(codeInput);
+    if (!token) {
+      setRecvError('Enter the access key or paste the share link.');
+      return;
+    }
+    setOpening(true);
+    try {
+      const id = await deriveId(token);
+      const res = await openSecret(id);
+      let decoded: VaultManifest;
+      try {
+        decoded = await decryptManifest(token, res.ct, res.iv);
+      } catch {
+        throw new Error('decrypt');
+      }
+      setManifest(decoded);
+      setRemaining(res.remaining);
+      track('vault_open', { contentType: res.contentType });
+    } catch (e) {
+      setRecvError(friendly(e instanceof Error ? e.message : ''));
+    } finally {
+      setOpening(false);
+    }
+  };
+
+  const ttlLabel = TTL_OPTIONS.find((t) => t.hours === ttlHours)?.label ?? `${ttlHours}h`;
+
+  if (!open) return null;
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/80 backdrop-blur-sm p-4 sm:p-8"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        onClick={onClose}
+      >
+        <motion.div
+          className="relative w-full max-w-2xl bg-zinc-900 border border-zinc-800 font-mono my-4"
+          initial={{ opacity: 0, y: 24, scale: 0.98 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          exit={{ opacity: 0, y: 12, scale: 0.98 }}
+          transition={{ duration: 0.25 }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          {/* corner accents */}
+          <div className="absolute -top-1 -left-1 w-3 h-3 border-t border-l border-cyan-500" />
+          <div className="absolute -bottom-1 -right-1 w-3 h-3 border-b border-r border-cyan-500" />
+
+          {/* header */}
+          <div className="flex items-center justify-between border-b border-zinc-800 bg-zinc-950 px-5 py-3">
+            <div className="flex items-center gap-2 text-cyan-500">
+              <Lock size={15} />
+              <span className="text-xs font-bold tracking-widest">SECURE_VAULT</span>
+              <span className="hidden sm:inline text-[10px] text-zinc-600">// end-to-end encrypted</span>
+            </div>
+            <button onClick={onClose} className="text-zinc-500 hover:text-zinc-200 transition-colors" title="Close (Esc)">
+              <X size={18} />
+            </button>
+          </div>
+
+          {/* tabs */}
+          <div className="grid grid-cols-2 border-b border-zinc-800">
+            {([
+              { id: 'send' as Tab, label: 'SEND', icon: <Send size={14} /> },
+              { id: 'receive' as Tab, label: 'RECEIVE', icon: <Inbox size={14} /> },
+            ]).map((t) => (
+              <button
+                key={t.id}
+                onClick={() => setTab(t.id)}
+                className={`flex items-center justify-center gap-2 py-3 text-xs uppercase tracking-widest transition-colors ${
+                  tab === t.id
+                    ? 'text-cyan-400 bg-zinc-900 border-b-2 border-cyan-500'
+                    : 'text-zinc-500 hover:text-zinc-300 border-b-2 border-transparent'
+                }`}
+              >
+                {t.icon}
+                {t.label}
+              </button>
+            ))}
+          </div>
+
+          <div className="p-5 max-h-[70vh] overflow-y-auto custom-scrollbar">
+            {tab === 'send' ? (
+              result ? (
+                /* ---- SEND: result ---- */
+                <div className="space-y-5">
+                  <div className="flex items-center gap-2 text-green-400 text-sm">
+                    <ShieldCheck size={18} />
+                    <span>Encrypted &amp; stored. Share these with your recipient.</span>
+                  </div>
+
+                  <div className="space-y-2">
+                    <label className="text-[11px] uppercase tracking-widest text-zinc-500 flex items-center gap-1.5">
+                      <KeyRound size={12} /> Access key
+                    </label>
+                    <div className="flex items-center gap-2">
+                      <code className="flex-1 bg-zinc-950 border border-zinc-800 px-3 py-2.5 text-cyan-300 text-sm break-all select-all">
+                        {result.code}
+                      </code>
+                      <CopyButton value={result.code} />
+                    </div>
+                  </div>
+
+                  <div className="space-y-2">
+                    <label className="text-[11px] uppercase tracking-widest text-zinc-500 flex items-center gap-1.5">
+                      <Link2 size={12} /> Share link
+                    </label>
+                    <div className="flex items-center gap-2">
+                      <code className="flex-1 bg-zinc-950 border border-zinc-800 px-3 py-2.5 text-zinc-300 text-xs break-all select-all">
+                        {result.link}
+                      </code>
+                      <CopyButton value={result.link} />
+                    </div>
+                  </div>
+
+                  <div className="text-xs text-zinc-500 leading-relaxed border-l-2 border-zinc-800 pl-3 space-y-1">
+                    <p className="flex items-center gap-1.5"><Eye size={12} /> Opens allowed: <span className="text-zinc-300">{maxViews}</span></p>
+                    <p className="flex items-center gap-1.5"><Clock size={12} /> Expires after: <span className="text-zinc-300">{ttlLabel}</span></p>
+                    <p className="flex items-center gap-1.5 text-amber-500/90"><AlertTriangle size={12} /> Anyone with the key can read it. For best safety, send the key and link over <span className="text-amber-300">separate channels</span>.</p>
+                  </div>
+
+                  <button
+                    onClick={resetSend}
+                    className="w-full flex items-center justify-center gap-2 py-3 bg-zinc-950 border border-zinc-800 text-xs uppercase tracking-widest text-zinc-300 hover:border-cyan-500/50 hover:text-cyan-400 transition-colors"
+                  >
+                    <Plus size={14} /> Share something else
+                  </button>
+                </div>
+              ) : (
+                /* ---- SEND: compose ---- */
+                <div className="space-y-5">
+                  {/* dropzone */}
+                  <div
+                    onDragOver={(e) => { e.preventDefault(); setDragging(true); }}
+                    onDragLeave={() => setDragging(false)}
+                    onDrop={onDrop}
+                    onClick={() => fileInputRef.current?.click()}
+                    className={`flex flex-col items-center justify-center gap-2 border border-dashed py-7 cursor-pointer transition-colors ${
+                      dragging ? 'border-cyan-500 bg-cyan-950/10' : 'border-zinc-700 hover:border-zinc-600 bg-zinc-950'
+                    }`}
+                  >
+                    <Upload size={22} className="text-zinc-500" />
+                    <p className="text-xs text-zinc-400">Drop files here or <span className="text-cyan-400">browse</span></p>
+                    <p className="text-[10px] text-zinc-600">.env, keys, certs — anything. Encrypted in your browser.</p>
+                    <input
+                      ref={fileInputRef}
+                      type="file"
+                      multiple
+                      hidden
+                      onChange={(e) => e.target.files && addFiles(e.target.files)}
+                    />
+                  </div>
+
+                  {/* file list */}
+                  {files.length > 0 && (
+                    <div className="space-y-1.5">
+                      {files.map((f, i) => (
+                        <div key={i} className="flex items-center gap-2 bg-zinc-950 border border-zinc-800 px-3 py-2">
+                          <FileText size={14} className="text-cyan-500 shrink-0" />
+                          <span className="flex-1 text-xs text-zinc-300 truncate">{f.name}</span>
+                          <span className="text-[10px] text-zinc-600">{formatBytes(f.size)}</span>
+                          <button onClick={() => removeFile(i)} className="text-zinc-600 hover:text-red-400 transition-colors">
+                            <Trash2 size={13} />
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+
+                  {/* text */}
+                  <div className="space-y-2">
+                    <label className="text-[11px] uppercase tracking-widest text-zinc-500">…or paste text</label>
+                    <textarea
+                      value={text}
+                      onChange={(e) => setText(e.target.value)}
+                      rows={4}
+                      placeholder={'# .env.local\nDATABASE_URL=...\nAPI_KEY=...'}
+                      className="w-full bg-zinc-950 border border-zinc-800 px-3 py-2.5 text-xs text-zinc-200 placeholder:text-zinc-700 focus:border-cyan-500/60 outline-none resize-y"
+                    />
+                  </div>
+
+                  {/* limits */}
+                  <div className="grid grid-cols-2 gap-4">
+                    <div className="space-y-2">
+                      <label className="text-[11px] uppercase tracking-widest text-zinc-500 flex items-center gap-1.5">
+                        <Eye size={12} /> Max opens
+                      </label>
+                      <input
+                        type="number"
+                        min={1}
+                        max={100}
+                        value={maxViews}
+                        onChange={(e) => setMaxViews(Math.max(1, Math.min(100, Number(e.target.value) || 1)))}
+                        className="w-full bg-zinc-950 border border-zinc-800 px-3 py-2.5 text-sm text-zinc-200 focus:border-cyan-500/60 outline-none"
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <label className="text-[11px] uppercase tracking-widest text-zinc-500 flex items-center gap-1.5">
+                        <Clock size={12} /> Expires in
+                      </label>
+                      <select
+                        value={ttlHours}
+                        onChange={(e) => setTtlHours(Number(e.target.value))}
+                        className="w-full bg-zinc-950 border border-zinc-800 px-3 py-2.5 text-sm text-zinc-200 focus:border-cyan-500/60 outline-none"
+                      >
+                        {TTL_OPTIONS.map((t) => (
+                          <option key={t.hours} value={t.hours}>{t.label}</option>
+                        ))}
+                      </select>
+                    </div>
+                  </div>
+
+                  {(files.length > 0 || text) && (
+                    <p className="text-[10px] text-zinc-600 text-right">
+                      payload: {formatBytes(totalRaw)} / {formatBytes(MAX_RAW_BYTES)}
+                    </p>
+                  )}
+
+                  {sendError && (
+                    <div className="flex items-center gap-2 text-xs text-red-400 border border-red-900/50 bg-red-950/20 px-3 py-2">
+                      <AlertTriangle size={14} /> {sendError}
+                    </div>
+                  )}
+
+                  <button
+                    onClick={handleGenerate}
+                    disabled={creating}
+                    className="w-full flex items-center justify-center gap-2 py-3.5 bg-cyan-950/40 border border-cyan-700/60 text-sm uppercase tracking-widest text-cyan-300 hover:bg-cyan-900/40 hover:border-cyan-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {creating ? <Loader2 size={16} className="animate-spin" /> : <KeyRound size={16} />}
+                    {creating ? 'Encrypting…' : 'Generate access key'}
+                  </button>
+                </div>
+              )
+            ) : (
+              /* ---- RECEIVE ---- */
+              <div className="space-y-5">
+                <div className="space-y-2">
+                  <label className="text-[11px] uppercase tracking-widest text-zinc-500 flex items-center gap-1.5">
+                    <KeyRound size={12} /> Access key or share link
+                  </label>
+                  <input
+                    value={codeInput}
+                    onChange={(e) => setCodeInput(e.target.value)}
+                    onKeyDown={(e) => e.key === 'Enter' && handleUnlock()}
+                    placeholder="XXXX-XXXX-XXXX-… or paste the link"
+                    className="w-full bg-zinc-950 border border-zinc-800 px-3 py-2.5 text-sm text-cyan-300 placeholder:text-zinc-700 focus:border-cyan-500/60 outline-none"
+                  />
+                  <p className="text-[10px] text-zinc-600 flex items-center gap-1.5">
+                    <AlertTriangle size={11} /> Unlocking uses one of the allowed opens.
+                  </p>
+                </div>
+
+                {recvError && (
+                  <div className="flex items-center gap-2 text-xs text-red-400 border border-red-900/50 bg-red-950/20 px-3 py-2">
+                    <AlertTriangle size={14} /> {recvError}
+                  </div>
+                )}
+
+                {!manifest && (
+                  <button
+                    onClick={handleUnlock}
+                    disabled={opening}
+                    className="w-full flex items-center justify-center gap-2 py-3.5 bg-cyan-950/40 border border-cyan-700/60 text-sm uppercase tracking-widest text-cyan-300 hover:bg-cyan-900/40 hover:border-cyan-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {opening ? <Loader2 size={16} className="animate-spin" /> : <Lock size={16} />}
+                    {opening ? 'Decrypting…' : 'Unlock'}
+                  </button>
+                )}
+
+                {manifest && (
+                  <div className="space-y-4">
+                    <div className="flex items-center justify-between text-xs">
+                      <span className="flex items-center gap-1.5 text-green-400"><ShieldCheck size={15} /> Decrypted</span>
+                      <span className="text-zinc-500">
+                        {remaining === 0 ? (
+                          <span className="text-amber-400">final access — now destroyed</span>
+                        ) : (
+                          <>opens left: <span className="text-zinc-300">{remaining}</span></>
+                        )}
+                      </span>
+                    </div>
+
+                    {manifest.files.map((f, i) => {
+                      const textable = isProbablyText(f.b64);
+                      return (
+                        <div key={i} className="bg-zinc-950 border border-zinc-800">
+                          <div className="flex items-center gap-2 border-b border-zinc-800 px-3 py-2">
+                            <FileText size={14} className="text-cyan-500 shrink-0" />
+                            <span className="flex-1 text-xs text-zinc-300 truncate">{f.name}</span>
+                            <span className="text-[10px] text-zinc-600">{formatBytes(f.size)}</span>
+                            {textable && <CopyButton value={base64ToText(f.b64)} />}
+                            <button
+                              onClick={() => downloadBlob(f.name, base64ToBlob(f.b64))}
+                              className="flex items-center gap-1.5 px-2.5 py-1.5 font-mono text-[11px] uppercase border border-zinc-700 text-zinc-400 hover:border-cyan-500/60 hover:text-cyan-400 transition-colors"
+                            >
+                              <Download size={13} /> SAVE
+                            </button>
+                          </div>
+                          {textable && (
+                            <pre className="px-3 py-2 text-[11px] text-zinc-400 whitespace-pre-wrap break-all max-h-40 overflow-y-auto custom-scrollbar">
+                              {base64ToText(f.b64)}
+                            </pre>
+                          )}
+                        </div>
+                      );
+                    })}
+
+                    {manifest.text && (
+                      <div className="bg-zinc-950 border border-zinc-800">
+                        <div className="flex items-center gap-2 border-b border-zinc-800 px-3 py-2">
+                          <FileText size={14} className="text-cyan-500" />
+                          <span className="flex-1 text-xs text-zinc-300">pasted text</span>
+                          <CopyButton value={manifest.text} />
+                          <button
+                            onClick={() => downloadBlob('secret.txt', base64ToBlob(btoa(unescape(encodeURIComponent(manifest.text!))), 'text/plain'))}
+                            className="flex items-center gap-1.5 px-2.5 py-1.5 font-mono text-[11px] uppercase border border-zinc-700 text-zinc-400 hover:border-cyan-500/60 hover:text-cyan-400 transition-colors"
+                          >
+                            <Download size={13} /> SAVE
+                          </button>
+                        </div>
+                        <pre className="px-3 py-2 text-[11px] text-zinc-400 whitespace-pre-wrap break-all max-h-48 overflow-y-auto custom-scrollbar">
+                          {manifest.text}
+                        </pre>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </motion.div>
+      </motion.div>
+    </AnimatePresence>
+  );
+};
+
+export default Vault;

--- a/constants.ts
+++ b/constants.ts
@@ -20,6 +20,15 @@ export const PROFILE = {
 
 export const PROJECTS: Project[] = [
   {
+    id: "P0",
+    title: "SECURE_VAULT",
+    pitch: "Zero-knowledge secret sharing. Encrypts files & .env vars in your browser, then mints a one-time access key + link with view limits and auto-expiry. Cloudflare Workers + KV.",
+    stack: ["React", "WebCrypto", "Cloudflare"],
+    image: "https://picsum.photos/seed/securevault/400/250?grayscale&blur=2",
+    status: "live",
+    action: "vault"
+  },
+  {
     id: "P1",
     title: "NEURO_VIS_V1",
     pitch: "Real-time EEG signal visualization using WebGL and Python.",

--- a/env.d.ts
+++ b/env.d.ts
@@ -8,6 +8,9 @@ interface ImportMetaEnv {
   readonly VITE_FIREBASE_MESSAGING_SENDER_ID?: string;
   readonly VITE_FIREBASE_APP_ID?: string;
   readonly VITE_FIREBASE_MEASUREMENT_ID?: string;
+  // SECURE_VAULT backend (Cloudflare Worker). Optional — a public default is
+  // baked into lib/vault-api.ts, so this only overrides it when set.
+  readonly VITE_VAULT_API_URL?: string;
 }
 
 interface ImportMeta {

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -1,27 +1,37 @@
 /**
  * Firebase initialization + Analytics.
  *
- * Config is read from Vite env vars (VITE_FIREBASE_*) so nothing secret is
- * committed. Firebase web config values are technically public, but keeping
- * them in env keeps the repo clean and lets the build run without them.
+ * The Firebase web config below is public by design (Google ships it in client
+ * code) — security comes from Firebase rules / App Check, not from hiding these
+ * values. They're set as fallback defaults so Analytics works on any host
+ * (incl. the current GitHub Pages deploy) without extra setup. The matching
+ * VITE_FIREBASE_* env vars still override them if present (see .env.example).
  *
  * The Firebase SDK is loaded via dynamic import() so it lands in its own async
- * chunk and never blocks first paint. If config is missing (e.g. local dev with
- * no .env), this module no-ops instead of throwing, so the site always renders.
- *
- * Setup: copy .env.example -> .env and fill in the values from your Firebase
- * project settings (Project settings -> General -> Your apps -> SDK setup).
+ * chunk and never blocks first paint, and init is wrapped so analytics can
+ * never break the page.
  */
 import type { Analytics } from 'firebase/analytics';
 
+// Project: mehdi-00. Public web config — safe to commit.
+const DEFAULT_CONFIG = {
+  apiKey: 'AIzaSyBABhCSUEqUlX998QaAYICFsIP9eUKkcBc',
+  authDomain: 'mehdi-00.firebaseapp.com',
+  projectId: 'mehdi-00',
+  storageBucket: 'mehdi-00.firebasestorage.app',
+  messagingSenderId: '857525867185',
+  appId: '1:857525867185:web:562abddbe8ea24b9db8890',
+  measurementId: 'G-N70BVPZ6JP',
+};
+
 const firebaseConfig = {
-  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
-  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
-  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
-  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
-  appId: import.meta.env.VITE_FIREBASE_APP_ID,
-  measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID,
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY ?? DEFAULT_CONFIG.apiKey,
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN ?? DEFAULT_CONFIG.authDomain,
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID ?? DEFAULT_CONFIG.projectId,
+  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET ?? DEFAULT_CONFIG.storageBucket,
+  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID ?? DEFAULT_CONFIG.messagingSenderId,
+  appId: import.meta.env.VITE_FIREBASE_APP_ID ?? DEFAULT_CONFIG.appId,
+  measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID ?? DEFAULT_CONFIG.measurementId,
 };
 
 const isConfigured = Boolean(firebaseConfig.apiKey && firebaseConfig.projectId);

--- a/lib/vault-api.ts
+++ b/lib/vault-api.ts
@@ -1,0 +1,69 @@
+/**
+ * SECURE_VAULT — client for the Cloudflare Worker backend.
+ *
+ * The Worker only ever stores ciphertext + IV, enforces the access-count, and
+ * relies on KV's native TTL for expiry. The base URL is public, so (mirroring
+ * lib/firebase.ts) we bake in a default and let a VITE_VAULT_API_URL env var
+ * override it. This keeps the GitHub Pages build working without CI secrets.
+ */
+
+// Set after the first `wrangler deploy` (its *.workers.dev URL).
+const DEFAULT_VAULT_API = 'https://mehdi-vault.mehdiacho.workers.dev';
+
+const API = (import.meta.env.VITE_VAULT_API_URL ?? DEFAULT_VAULT_API).replace(/\/+$/, '');
+
+export interface CreateInput {
+  id: string;
+  ct: string;
+  iv: string;
+  maxViews: number;
+  ttlHours: number;
+  contentType: 'files' | 'text' | 'mixed';
+  size: number;
+}
+
+export interface OpenResult {
+  ct: string;
+  iv: string;
+  contentType: string;
+  remaining: number;
+}
+
+async function errorFrom(res: Response): Promise<string> {
+  try {
+    const data = await res.json();
+    if (data && typeof data.error === 'string') return data.error;
+  } catch {
+    /* ignore */
+  }
+  return `http_${res.status}`;
+}
+
+export async function createSecret(input: CreateInput): Promise<void> {
+  let res: Response;
+  try {
+    res = await fetch(`${API}/api/secrets`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(input),
+    });
+  } catch {
+    throw new Error('network_error');
+  }
+  if (!res.ok) throw new Error(await errorFrom(res));
+}
+
+export async function openSecret(id: string): Promise<OpenResult> {
+  let res: Response;
+  try {
+    res = await fetch(`${API}/api/secrets/get`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ id }),
+    });
+  } catch {
+    throw new Error('network_error');
+  }
+  if (!res.ok) throw new Error(await errorFrom(res));
+  return (await res.json()) as OpenResult;
+}

--- a/lib/vault-crypto.ts
+++ b/lib/vault-crypto.ts
@@ -1,0 +1,182 @@
+/**
+ * SECURE_VAULT — zero-knowledge client-side crypto.
+ *
+ * The whole security model lives here. A random "token" is the ONLY secret.
+ * From it we derive:
+ *   - a public lookup `id`  (sent to the Worker, safe to store)
+ *   - a private AES-GCM key (derived locally, NEVER sent anywhere)
+ *
+ * The token travels to the recipient only as the typeable code or inside the
+ * link's URL hash fragment (`#vault=<token>`), which browsers never transmit to
+ * a server. So the Worker (and its operator) only ever sees ciphertext + IV and
+ * can never read the secrets. Wrong token => AES-GCM decrypt throws.
+ *
+ * Uses the WebCrypto API only — no dependencies.
+ */
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+// Crockford base32 alphabet (excludes I, L, O, U to avoid ambiguity).
+const B32 = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+// ---- low-level encodings ---------------------------------------------------
+
+function bytesToBase32(bytes: Uint8Array): string {
+  let bits = 0;
+  let value = 0;
+  let out = '';
+  for (const b of bytes) {
+    value = (value << 8) | b;
+    bits += 8;
+    while (bits >= 5) {
+      out += B32[(value >>> (bits - 5)) & 31];
+      bits -= 5;
+    }
+  }
+  if (bits > 0) out += B32[(value << (5 - bits)) & 31];
+  return out;
+}
+
+function hex(bytes: Uint8Array): string {
+  let s = '';
+  for (const b of bytes) s += b.toString(16).padStart(2, '0');
+  return s;
+}
+
+function b64encode(bytes: Uint8Array): string {
+  let s = '';
+  for (const b of bytes) s += String.fromCharCode(b);
+  return btoa(s);
+}
+
+function b64decode(str: string): Uint8Array {
+  const bin = atob(str);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+async function sha256(data: Uint8Array): Promise<Uint8Array> {
+  const buf = await crypto.subtle.digest('SHA-256', data);
+  return new Uint8Array(buf);
+}
+
+// ---- token / code ----------------------------------------------------------
+
+/** Random 120-bit token, encoded as 24 Crockford-base32 chars. */
+export function generateToken(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(15)); // 120 bits
+  return bytesToBase32(bytes);
+}
+
+/** Pretty-print a token as a grouped code: XXXX-XXXX-XXXX-... */
+export function formatCode(token: string): string {
+  return token.replace(/(.{4})/g, '$1-').replace(/-+$/, '');
+}
+
+/**
+ * Accept a raw code, a grouped code, or a full share link, and return the bare
+ * canonical token. Maps the visually ambiguous chars a human might type
+ * (I/L -> 1, O -> 0) onto the Crockford alphabet.
+ */
+export function normalizeCode(input: string): string {
+  let s = (input || '').trim();
+  const marker = 'vault=';
+  const idx = s.indexOf(marker);
+  if (idx !== -1) s = s.slice(idx + marker.length);
+  s = s.toUpperCase().replace(/[^A-Z0-9]/g, '');
+  s = s.replace(/O/g, '0').replace(/[IL]/g, '1');
+  return s;
+}
+
+/** Build the share link that carries the token in the (server-invisible) hash. */
+export function buildShareLink(token: string): string {
+  const base = `${location.origin}${location.pathname}`;
+  return `${base}#vault=${token}`;
+}
+
+// ---- key derivation --------------------------------------------------------
+
+/** Public lookup id (32 hex chars) — safe to send to the server. */
+export async function deriveId(token: string): Promise<string> {
+  const h = await sha256(enc.encode(`${token}|id|v1`));
+  return hex(h.slice(0, 16));
+}
+
+/** Private AES-GCM-256 key derived from the token. Never leaves the browser. */
+export async function deriveKey(token: string): Promise<CryptoKey> {
+  const ikm = await crypto.subtle.importKey('raw', enc.encode(token), 'HKDF', false, ['deriveKey']);
+  return crypto.subtle.deriveKey(
+    {
+      name: 'HKDF',
+      hash: 'SHA-256',
+      salt: enc.encode('vault|salt|v1'),
+      info: enc.encode('vault|enc|v1'),
+    },
+    ikm,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+}
+
+// ---- payload encryption ----------------------------------------------------
+
+export interface VaultFile {
+  name: string;
+  /** base64 of the raw file bytes */
+  b64: string;
+  size: number;
+}
+
+export interface VaultManifest {
+  files: VaultFile[];
+  text?: string;
+}
+
+export interface EncryptedBlob {
+  ct: string; // base64 ciphertext
+  iv: string; // base64 IV
+}
+
+export async function encryptManifest(token: string, manifest: VaultManifest): Promise<EncryptedBlob> {
+  const key = await deriveKey(token);
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const data = enc.encode(JSON.stringify(manifest));
+  const ctBuf = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, data);
+  return { ct: b64encode(new Uint8Array(ctBuf)), iv: b64encode(iv) };
+}
+
+export async function decryptManifest(token: string, ct: string, iv: string): Promise<VaultManifest> {
+  const key = await deriveKey(token);
+  const ptBuf = await crypto.subtle.decrypt({ name: 'AES-GCM', iv: b64decode(iv) }, key, b64decode(ct));
+  return JSON.parse(dec.decode(new Uint8Array(ptBuf))) as VaultManifest;
+}
+
+// ---- file helpers (used by the UI) ----------------------------------------
+
+/** Read a File into a base64 string (raw bytes). */
+export function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(reader.error);
+    reader.onload = () => {
+      const result = reader.result as string;
+      // result is a data URL: "data:...;base64,XXXX" — keep only the payload.
+      const comma = result.indexOf(',');
+      resolve(comma === -1 ? result : result.slice(comma + 1));
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
+/** Decode a base64 string into a Blob for download. */
+export function base64ToBlob(b64: string, type = 'application/octet-stream'): Blob {
+  return new Blob([b64decode(b64)], { type });
+}
+
+/** Best-effort UTF-8 decode of a base64 payload (for previewing text files). */
+export function base64ToText(b64: string): string {
+  return dec.decode(b64decode(b64));
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,5 +26,10 @@
     },
     "allowImportingTsExtensions": true,
     "noEmit": true
-  }
+  },
+  "exclude": [
+    "worker",
+    "node_modules",
+    "dist"
+  ]
 }

--- a/types.ts
+++ b/types.ts
@@ -8,6 +8,8 @@ export interface Project {
   image: string;
   link?: string;
   github?: string;
+  /** In-site action instead of an external link. 'vault' opens SECURE_VAULT. */
+  action?: 'vault';
   /**
    * Honest build state. Drives the badge shown on the card.
    * 'live'    - shipped, has a real demo/source

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,0 +1,1627 @@
+{
+  "name": "mehdi-vault-worker",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mehdi-vault-worker",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20240909.0",
+        "wrangler": "^3.78.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.4.tgz",
+      "integrity": "sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "mime": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.0.2.tgz",
+      "integrity": "sha512-nyzYnlZjjV5xT3LizahG1Iu6mnrCaxglJ04rZLpDwlDVDZ7v46lNsfxhV3A/xtfgQuSHmLnc6SVI+KwBpc3Lwg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.14",
+        "workerd": "^1.20250124.0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250718.0.tgz",
+      "integrity": "sha512-FHf4t7zbVN8yyXgQ/r/GqLPaYZSGUVzeR7RnL28Mwj2djyw2ZergvytVc7fdGcczl6PQh+VKGfZCfUqpJlbi9g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250718.0.tgz",
+      "integrity": "sha512-fUiyUJYyqqp4NqJ0YgGtp4WJh/II/YZsUnEb6vVy5Oeas8lUOxnN+ZOJ8N/6/5LQCVAtYCChRiIrBbfhTn5Z8Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250718.0.tgz",
+      "integrity": "sha512-5+eb3rtJMiEwp08Kryqzzu8d1rUcK+gdE442auo5eniMpT170Dz0QxBrqkg2Z48SFUPYbj+6uknuA5tzdRSUSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250718.0.tgz",
+      "integrity": "sha512-Aa2M/DVBEBQDdATMbn217zCSFKE+ud/teS+fFS+OQqKABLn0azO2qq6ANAHYOIE6Q3Sq4CxDIQr8lGdaJHwUog==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250718.0.tgz",
+      "integrity": "sha512-dY16RXKffmugnc67LTbyjdDHZn5NoTF1yHEf2fN4+OaOnoGSp3N1x77QubTDwqZ9zECWxgQfDLjddcH8dWeFhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260625.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260625.1.tgz",
+      "integrity": "sha512-asH0RhPHiNu/IUSssyiOJYAcGqysy0DJpO9fihC6KATaayD9CE1E9bgNQozTLUraxrCT2qkM4CBOIcV0M5NPJw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-globals-polyfill": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.2.3.tgz",
+      "integrity": "sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-modules-polyfill": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.2.2.tgz",
+      "integrity": "sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "rollup-plugin-node-polyfills": "^0.2.1"
+      },
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
+      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
+      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
+      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
+      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
+      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
+      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
+      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
+      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
+      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
+      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
+      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
+      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
+      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
+      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
+      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
+      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
+      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
+      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
+      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
+      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/as-table": {
+      "version": "1.0.55",
+      "resolved": "https://registry.npmjs.org/as-table/-/as-table-1.0.55.tgz",
+      "integrity": "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "printable-characters": "^1.0.42"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
+      "integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
+      "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.17.19",
+        "@esbuild/android-arm64": "0.17.19",
+        "@esbuild/android-x64": "0.17.19",
+        "@esbuild/darwin-arm64": "0.17.19",
+        "@esbuild/darwin-x64": "0.17.19",
+        "@esbuild/freebsd-arm64": "0.17.19",
+        "@esbuild/freebsd-x64": "0.17.19",
+        "@esbuild/linux-arm": "0.17.19",
+        "@esbuild/linux-arm64": "0.17.19",
+        "@esbuild/linux-ia32": "0.17.19",
+        "@esbuild/linux-loong64": "0.17.19",
+        "@esbuild/linux-mips64el": "0.17.19",
+        "@esbuild/linux-ppc64": "0.17.19",
+        "@esbuild/linux-riscv64": "0.17.19",
+        "@esbuild/linux-s390x": "0.17.19",
+        "@esbuild/linux-x64": "0.17.19",
+        "@esbuild/netbsd-x64": "0.17.19",
+        "@esbuild/openbsd-x64": "0.17.19",
+        "@esbuild/sunos-x64": "0.17.19",
+        "@esbuild/win32-arm64": "0.17.19",
+        "@esbuild/win32-ia32": "0.17.19",
+        "@esbuild/win32-x64": "0.17.19"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/exit-hook": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
+      "integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/exsolve": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
+      "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-source": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/get-source/-/get-source-2.0.12.tgz",
+      "integrity": "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "data-uri-to-buffer": "^2.0.0",
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "3.20250718.3",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20250718.3.tgz",
+      "integrity": "sha512-JuPrDJhwLrNLEJiNLWO7ZzJrv/Vv9kZuwMYCfv0LskQDM6Eonw4OvywO3CH/wCGjgHzha/qyjUh8JQ068TjDgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "acorn": "8.14.0",
+        "acorn-walk": "8.3.2",
+        "exit-hook": "2.2.1",
+        "glob-to-regexp": "0.4.1",
+        "stoppable": "1.1.0",
+        "undici": "^5.28.5",
+        "workerd": "1.20250718.0",
+        "ws": "8.18.0",
+        "youch": "3.3.4",
+        "zod": "3.22.3"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/printable-characters": {
+      "version": "1.0.42",
+      "resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
+      "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
+      "dev": true,
+      "license": "Unlicense"
+    },
+    "node_modules/rollup-plugin-inject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz",
+      "integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
+      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1",
+        "magic-string": "^0.25.3",
+        "rollup-pluginutils": "^2.8.1"
+      }
+    },
+    "node_modules/rollup-plugin-node-polyfills": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
+      "integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rollup-plugin-inject": "^3.0.0"
+      }
+    },
+    "node_modules/rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stacktracey": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.2.0.tgz",
+      "integrity": "sha512-ETyQEz+CzXiLjEbyJqpbp+/T79RQD/6wqFucRBIlVNZfYq2Ay7wbretD4cxpbymZlaPWx58aIhPEY1Cr8DlVvg==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "as-table": "^1.0.36",
+        "get-source": "^2.0.12"
+      }
+    },
+    "node_modules/stoppable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.14",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.14.tgz",
+      "integrity": "sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "exsolve": "^1.0.1",
+        "ohash": "^2.0.10",
+        "pathe": "^2.0.3",
+        "ufo": "^1.5.4"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250718.0.tgz",
+      "integrity": "sha512-kqkIJP/eOfDlUyBzU7joBg+tl8aB25gEAGqDap+nFWb+WHhnooxjGHgxPBy3ipw2hnShPFNOQt5lFRxbwALirg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20250718.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20250718.0",
+        "@cloudflare/workerd-linux-64": "1.20250718.0",
+        "@cloudflare/workerd-linux-arm64": "1.20250718.0",
+        "@cloudflare/workerd-windows-64": "1.20250718.0"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "3.114.17",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.114.17.tgz",
+      "integrity": "sha512-tAvf7ly+tB+zwwrmjsCyJ2pJnnc7SZhbnNwXbH+OIdVas3zTSmjcZOjmLKcGGptssAA3RyTKhcF9BvKZzMUycA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.3.4",
+        "@cloudflare/unenv-preset": "2.0.2",
+        "@esbuild-plugins/node-globals-polyfill": "0.2.3",
+        "@esbuild-plugins/node-modules-polyfill": "0.2.2",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.17.19",
+        "miniflare": "3.20250718.3",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.14",
+        "workerd": "1.20250718.0"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2",
+        "sharp": "^0.33.5"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20250408.0"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-3.3.4.tgz",
+      "integrity": "sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^0.7.1",
+        "mustache": "^4.2.0",
+        "stacktracey": "^2.1.8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
+      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "mehdi-vault-worker",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "tail": "wrangler tail"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240909.0",
+    "wrangler": "^3.78.0"
+  }
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,0 +1,148 @@
+/**
+ * SECURE_VAULT — Cloudflare Worker backend.
+ *
+ * Stores only ciphertext + IV (the encryption happens in the browser; see
+ * lib/vault-crypto.ts). Enforces a per-secret access count and leans on KV's
+ * native TTL for time-based expiry. Burn-after-read: the record is deleted once
+ * its views are exhausted.
+ *
+ * Endpoints (all JSON):
+ *   POST /api/secrets       create  { id, ct, iv, maxViews, ttlHours, contentType, size }
+ *   POST /api/secrets/get   redeem  { id }  -> { ct, iv, contentType, remaining }
+ */
+
+export interface Env {
+  VAULT: KVNamespace;
+}
+
+interface VaultRecord {
+  ct: string;
+  iv: string;
+  maxViews: number;
+  views: number;
+  contentType: string;
+  size: number;
+  createdAt: number;
+  expiresAt: number;
+}
+
+const ALLOWED_ORIGINS = new Set([
+  'https://mehdiacho.tech',
+  'https://www.mehdiacho.tech',
+  'http://localhost:3000',
+  'http://127.0.0.1:3000',
+]);
+
+// base64 of ~256 KB of plaintext; generous for env files, caps abuse.
+const MAX_CT_CHARS = 360_000;
+const KV_MIN_TTL = 60; // Cloudflare KV minimum expirationTtl (seconds).
+
+function corsHeaders(origin: string | null): Record<string, string> {
+  const allow = origin && ALLOWED_ORIGINS.has(origin) ? origin : 'https://mehdiacho.tech';
+  return {
+    'Access-Control-Allow-Origin': allow,
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'content-type',
+    'Access-Control-Max-Age': '86400',
+    Vary: 'Origin',
+  };
+}
+
+function json(data: unknown, status: number, origin: string | null): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'content-type': 'application/json', ...corsHeaders(origin) },
+  });
+}
+
+const isId = (v: unknown): v is string => typeof v === 'string' && /^[a-f0-9]{32}$/.test(v);
+
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    const origin = req.headers.get('Origin');
+    if (req.method === 'OPTIONS') {
+      return new Response(null, { status: 204, headers: corsHeaders(origin) });
+    }
+    const url = new URL(req.url);
+    try {
+      if (req.method === 'POST' && url.pathname === '/api/secrets') {
+        return await create(req, env, origin);
+      }
+      if (req.method === 'POST' && url.pathname === '/api/secrets/get') {
+        return await open(req, env, origin);
+      }
+      return json({ error: 'not_found' }, 404, origin);
+    } catch {
+      return json({ error: 'bad_request' }, 400, origin);
+    }
+  },
+};
+
+async function create(req: Request, env: Env, origin: string | null): Promise<Response> {
+  const body = (await req.json()) as Partial<VaultRecord> & { id?: unknown; ttlHours?: unknown; maxViews?: unknown };
+  const { id, ct, iv, contentType } = body as { id: unknown; ct: unknown; iv: unknown; contentType: unknown };
+
+  if (!isId(id)) return json({ error: 'bad_id' }, 400, origin);
+  if (typeof ct !== 'string' || typeof iv !== 'string' || ct.length === 0) {
+    return json({ error: 'bad_payload' }, 400, origin);
+  }
+  if (ct.length > MAX_CT_CHARS) return json({ error: 'too_large' }, 413, origin);
+
+  const maxViews = Math.floor(Number((body as { maxViews: unknown }).maxViews));
+  if (!(maxViews >= 1 && maxViews <= 100)) return json({ error: 'bad_max_views' }, 400, origin);
+
+  const ttlHours = Math.floor(Number((body as { ttlHours: unknown }).ttlHours));
+  if (!(ttlHours >= 1 && ttlHours <= 168)) return json({ error: 'bad_ttl' }, 400, origin);
+
+  if (await env.VAULT.get(id)) return json({ error: 'id_exists' }, 409, origin);
+
+  const now = Date.now();
+  const record: VaultRecord = {
+    ct,
+    iv,
+    maxViews,
+    views: 0,
+    contentType: typeof contentType === 'string' ? contentType : 'files',
+    size: Number((body as { size: unknown }).size) || 0,
+    createdAt: now,
+    expiresAt: now + ttlHours * 3600 * 1000,
+  };
+  await env.VAULT.put(id, JSON.stringify(record), { expirationTtl: ttlHours * 3600 });
+  return json({ ok: true }, 200, origin);
+}
+
+async function open(req: Request, env: Env, origin: string | null): Promise<Response> {
+  const { id } = (await req.json()) as { id: unknown };
+  if (!isId(id)) return json({ error: 'bad_id' }, 400, origin);
+
+  const raw = await env.VAULT.get(id);
+  if (!raw) return json({ error: 'not_found_or_expired' }, 404, origin);
+
+  const record = JSON.parse(raw) as VaultRecord;
+  const now = Date.now();
+
+  // Defensive expiry check (KV TTL should already have removed it).
+  if (now >= record.expiresAt) {
+    await env.VAULT.delete(id);
+    return json({ error: 'not_found_or_expired' }, 404, origin);
+  }
+  if (record.views >= record.maxViews) {
+    await env.VAULT.delete(id);
+    return json({ error: 'exhausted' }, 410, origin);
+  }
+
+  record.views += 1;
+  const remaining = record.maxViews - record.views;
+
+  if (remaining <= 0) {
+    // Burn-after-read: last permitted view, delete immediately.
+    await env.VAULT.delete(id);
+  } else {
+    // Re-store with the ORIGINAL absolute expiry preserved (KV can't report
+    // the remaining TTL, so recompute it from expiresAt).
+    const ttl = Math.max(KV_MIN_TTL, Math.ceil((record.expiresAt - now) / 1000));
+    await env.VAULT.put(id, JSON.stringify(record), { expirationTtl: ttl });
+  }
+
+  return json({ ct: record.ct, iv: record.iv, contentType: record.contentType, remaining }, 200, origin);
+}

--- a/worker/tsconfig.json
+++ b/worker/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "isolatedModules": true
+  },
+  "include": ["src"]
+}

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,0 +1,17 @@
+# SECURE_VAULT Worker — deploy with `wrangler deploy` from this directory.
+#
+# First-time setup:
+#   1) wrangler login
+#   2) wrangler kv namespace create VAULT   # paste the returned id below
+#   3) wrangler deploy                      # note the *.workers.dev URL, then
+#      set it as DEFAULT_VAULT_API in ../lib/vault-api.ts (and/or VITE_VAULT_API_URL)
+name = "mehdi-vault"
+main = "src/index.ts"
+compatibility_date = "2024-09-23"
+
+[observability]
+enabled = true
+
+[[kv_namespaces]]
+binding = "VAULT"
+id = "c7c747ec8845400b856c29a5e2d7f928"


### PR DESCRIPTION
## What

Adds **SECURE_VAULT** — an end-to-end encrypted tool for passing secrets (e.g. the real `.env` files an `.env.example` only hints at). Reachable from the hero **SECURE_VAULT** button, the `vault` terminal command, a new live project card, and `#vault=<token>` share links.

- **SEND**: upload files and/or paste text, set a **max-opens** count and an **expiry** (1h–7d), get a short **access code** *and* a **share link**.
- **RECEIVE**: paste the code or open the link → decrypt in-browser → copy/download each file or the text.

## How it works (zero-knowledge)

A random token is the only secret. From it the client derives:
- a **public lookup id** (sent to the server, safe to store), and
- a **private AES-GCM key** (derived locally, never sent anywhere).

The token travels only as the typeable code or in the link's `#` fragment (never transmitted to a server). Payloads are encrypted with **WebCrypto** in the browser. The Cloudflare Worker stores **only ciphertext + IV**, enforces the access count (**burn-after-read**), and uses **KV's native TTL** for expiry. Neither the server nor its operator can read the secrets.

## Changes

| Area | File |
|------|------|
| Crypto | `lib/vault-crypto.ts` — token/code, HKDF key derivation, AES-GCM |
| API client | `lib/vault-api.ts` — public default + `VITE_VAULT_API_URL` override |
| Backend | `worker/` — Cloudflare Worker + KV (create / burn-on-read / TTL / CORS) |
| UI | `components/Vault.tsx` — SEND/RECEIVE modal |
| Wiring | `App.tsx`, `components/Terminal.tsx`, `components/Projects.tsx`, `constants.ts`, `types.ts` |
| Config | `.env.example`, `env.d.ts`, `tsconfig.json` (excludes `worker/`) |

## Deployment status

- Worker is **deployed** to `https://mehdi-vault.mehdiacho.workers.dev` (KV namespace `mehdi-vault-kv`). The frontend default URL already points there.
- Verified **live**: create → open (burns, `remaining:0`) → second open `404`; CORS locked to `mehdiacho.tech`. Crypto round-trip: 13/13 checks pass. `npm run build` succeeds.

## Notes

- Anyone with the code/link can read the secret (by design) — the UI advises sending the code and link over separate channels.
- KV's view counter is best-effort under rare simultaneous redemptions of the *same* secret (acceptable for this use case; Durable Objects noted as future hardening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)